### PR TITLE
fix: remove unnecssary library and fully move to docker

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y \
 
 COPY . .
 
-RUN rm -rf build out.exe && make ML="wine ML.EXE" LINK="wine link.exe"
+COPY ML.EXE .
+COPY link.exe .
 
 EXPOSE 8080
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-ML := ml
-LINK := link
+ML := wine ./ML.EXE
+LINK := wine ./link.exe
 
 TARGET_NAME = out.exe
 SRC_DIR = src

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as build-stage
+FROM node:20-alpine AS build-stage
 
 WORKDIR /app
 


### PR DESCRIPTION
As the whole project is running using docker-compsoe now, and the build process is automated and ran in Wine, so we don't need most of the library except Irvine32 